### PR TITLE
Reset password

### DIFF
--- a/src/lib/Api/auth.server.ts
+++ b/src/lib/Api/auth.server.ts
@@ -50,4 +50,85 @@ export default class AuthApi extends Api {
             throw new Error('Error Register : ' + error);
         }
     };
+
+    resetPasswordRequest = async (email: User['email']): Promise<ApiResponse> => {
+        try {
+            // Call api
+            const response = await this.fetch(
+                `${env.API_URL}reset-password`,
+                {
+                    method: 'post',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    credentials: 'include',
+                    body: JSON.stringify({ email })
+                }
+            );
+
+            // Convert response to json and return
+            const data: ApiResponse = await response.json();
+            return { ...data };
+        } catch (error) {
+
+            // If an error occur, log error and return error
+            console.error('Reset Password : ' + error);
+            throw new Error('Error Reset Password : ' + error);
+        }
+    };
+
+    chechResetRequest = async (token: string, userId: string): Promise<ApiResponse & { accessToken: string | null }> => {
+        try {
+            // Call api
+            const response = await this.fetch(
+                `${env.API_URL}check-request?token=${token}&userId=${userId}`,
+                {
+                    method: 'get',
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
+
+            const newAccessToken = response.headers.get('Authorization');
+
+            // Convert response to json and return
+            const data: ApiResponse = await response.json();
+            return { ...data, accessToken: newAccessToken };
+        } catch (error) {
+
+            // If an error occur, log error and return error
+            console.error('Check Reset : ' + error);
+            throw new Error('Error Check Reset : ' + error);
+        }
+    };
+
+    changePassword = async (password: string, password_confirmation: string, userId: string, token: string): Promise<ApiResponse & { accessToken: string | null }> => {
+        try {
+            // Call api
+            const response = await this.fetch(
+                `${env.API_URL}change-password`,
+                {
+                    method: 'post',
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ password, password_confirmation, userId, token })
+                }
+            );
+
+            const newAccessToken = response.headers.get('Authorization');
+
+            // Convert response to json and return
+            const data: ApiResponse = await response.json();
+            return { ...data, accessToken: newAccessToken };
+        } catch (error) {
+
+            // If an error occur, log error and return error
+            console.error('Change Password : ' + error);
+            throw new Error('Error Change Password : ' + error);
+        }
+    };
 }

--- a/src/routes/(auth)/changePassword/+page.server.ts
+++ b/src/routes/(auth)/changePassword/+page.server.ts
@@ -1,0 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load = (async (event) => {
+    const user = event.locals.user;
+    if (user) {
+        throw redirect(303, '/kodo');
+    }
+    return {};
+}) satisfies PageServerLoad;

--- a/src/routes/(auth)/changePassword/[userId]/+page.server.ts
+++ b/src/routes/(auth)/changePassword/[userId]/+page.server.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load = (async () => {
+
+    throw redirect(303, '/kodo');
+
+}) satisfies PageServerLoad;

--- a/src/routes/(auth)/changePassword/[userId]/[token]/+page.server.ts
+++ b/src/routes/(auth)/changePassword/[userId]/[token]/+page.server.ts
@@ -8,10 +8,10 @@ import AuthApi from '$lib/Api/auth.server';
 const newChangePasswordSchema = z.object({
     password: z.string()
         .min(8, 'Le mot de passe doit contenir au moins 8 caractères')
-        .max(30, 'Le mot de passe doit contenir au moins 30 caractères'),
+        .max(30, 'Le mot de passe doit contenir au maximum 30 caractères'),
     password_confirmation: z.string()
         .min(8, 'Le mot de passe doit contenir au moins 8 caractères')
-        .max(30, 'Le mot de passe doit contenir au moins 30 caractères'),
+        .max(30, 'Le mot de passe doit contenir au maximum 30 caractères'),
 })
 
 export const load = (async (event) => {

--- a/src/routes/(auth)/changePassword/[userId]/[token]/+page.server.ts
+++ b/src/routes/(auth)/changePassword/[userId]/[token]/+page.server.ts
@@ -1,0 +1,63 @@
+import { error, redirect, type Actions } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { z } from 'zod';
+import { superValidate, message, fail } from 'sveltekit-superforms/client';
+import { zod } from 'sveltekit-superforms/adapters';
+import AuthApi from '$lib/Api/auth.server';
+
+const newChangePasswordSchema = z.object({
+    password: z.string()
+        .min(8, 'Le mot de passe doit contenir au moins 8 caractères')
+        .max(30, 'Le mot de passe doit contenir au moins 30 caractères'),
+    password_confirmation: z.string()
+        .min(8, 'Le mot de passe doit contenir au moins 8 caractères')
+        .max(30, 'Le mot de passe doit contenir au moins 30 caractères'),
+})
+
+export const load = (async (event) => {
+
+    const apiPassword = new AuthApi(event.fetch)
+    const res = await apiPassword.chechResetRequest(event.params.token, event.params.userId);
+
+
+    if ("error" in res) {
+        throw error(404, 'Not found');
+    }
+
+    const form = await superValidate(event, zod(newChangePasswordSchema));
+
+    return {
+        form
+    };
+}) satisfies PageServerLoad;
+
+export const actions: Actions = {
+    default: async (event) => {
+
+        const apiPassword = new AuthApi(event.fetch)
+        const res = await apiPassword.chechResetRequest(event.params.token!, event.params.userId!);
+
+        if ("error" in res) {
+            throw error(404, 'Not found');
+        }
+
+        const form = await superValidate(event, zod(newChangePasswordSchema));
+
+        if (!form.valid) {
+            return fail(400, {
+                form
+            });
+        }
+
+        const api = new AuthApi(event.fetch);
+        const resPassword = await api.changePassword(form.data.password, form.data.password_confirmation, event.params.userId!, event.params.token!);
+
+        if ("error" in resPassword) {
+            return message(form, { error: resPassword.error.message }, {
+                status: resPassword.status
+            });
+        }
+
+        redirect(303, '/login');
+    }
+}

--- a/src/routes/(auth)/changePassword/[userId]/[token]/+page.svelte
+++ b/src/routes/(auth)/changePassword/[userId]/[token]/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import Input from '$lib/Component/form/Input.svelte';
+	import Label from '$lib/Component/form/Label.svelte';
+	import { superForm } from 'sveltekit-superforms/client';
+	import type { PageData } from './$types';
+	import SubmitButton from '$lib/Component/form/SubmitButton.svelte';
+	import toast from 'svelte-french-toast';
+	import { goto } from '$app/navigation';
+
+	export let data: PageData;
+
+	const { form, errors, enhance, message } = superForm(data.form, {
+		taintedMessage:
+			'Êtes vous sur de vouloir quitter cette page ? Les données ne seront pas sauvegardées'
+	});
+
+	if ($message && $message.success) {
+		$message.success = false;
+		toast.success('Votre mot de passe a été modifié avec succès !');
+		setTimeout(() => {
+			goto('/login');
+		}, 500);
+	}
+</script>
+
+<section class="container h-full mx-auto flex justify-center items-center">
+	<form method="post" use:enhance class="flex flex-col gap-8 w-full max-w-lg px-4">
+		<div class="!max-w-36 mx-auto">
+			<img src="https://kodo.evift.fr/logo_base.png" alt="Logo Kodo" />
+		</div>
+		<div class="flex flex-col gap-8">
+			<div class="flex flex-col gap-8">
+				<Label label="Nouveau mot de passe">
+					<Input
+						error={$errors.password}
+						bind:value={$form.password}
+						name="password"
+						type="password"
+						placeholder="Nouveau mot de passe..."
+					/>
+				</Label>
+
+				<Label label="Confirmation mot de passe">
+					<Input
+						error={$errors.password_confirmation}
+						bind:value={$form.password_confirmation}
+						name="password_confirmation"
+						type="password"
+						placeholder="Confirmation mot de passe..."
+					/>
+				</Label>
+			</div>
+			<SubmitButton>Envoyer</SubmitButton>
+		</div>
+	</form>
+</section>

--- a/src/routes/(auth)/login/+page.svelte
+++ b/src/routes/(auth)/login/+page.svelte
@@ -60,14 +60,7 @@
 			/>
 		</Label>
 		<div class="pl-6">
-			<button
-				type="button"
-				class="!text-secondary-500"
-				on:click={() =>
-					alert(
-						"Pas encore dispo, je n'ai eu que 3 jours... Vous pensiez vraiment que j'allais tout faire ? Non, laissez tomber, vous ne retrouverez pas votre mot de passe."
-					)}>Mot de passe oublié ?</button
-			>
+			<a href="/resetPassword" type="button" class="!text-secondary-500">Mot de passe oublié ?</a>
 		</div>
 
 		<label class="flex items-center gap-2 pl-2"> <input type="checkbox" /> Rester connecté </label>

--- a/src/routes/(auth)/register/+page.server.ts
+++ b/src/routes/(auth)/register/+page.server.ts
@@ -36,7 +36,7 @@ export const actions: Actions = {
 
         if ("error" in response) {
             return message(form, {
-                error: response.error.message,
+                error: response.error,
                 status: response.status
             });
         }

--- a/src/routes/(auth)/register/+page.svelte
+++ b/src/routes/(auth)/register/+page.svelte
@@ -33,7 +33,7 @@
 			}, 500);
 		}
 	}
-	$:console.log($message)
+	
 
 	$: {
 		if ($message && $message.error) {

--- a/src/routes/(auth)/register/+page.svelte
+++ b/src/routes/(auth)/register/+page.svelte
@@ -33,6 +33,7 @@
 			}, 500);
 		}
 	}
+	$:console.log($message)
 
 	$: {
 		if ($message && $message.error) {

--- a/src/routes/(auth)/resetPassword/+page.server.ts
+++ b/src/routes/(auth)/resetPassword/+page.server.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { PageServerLoad } from './$types';
+import { message, superValidate } from 'sveltekit-superforms/server';
+import { zod } from 'sveltekit-superforms/adapters';
+import { redirect, type Actions } from '@sveltejs/kit';
+import { fail } from 'sveltekit-superforms/client';
+import AuthApi from '$lib/Api/auth.server';
+
+
+const newResetPasswordSchema = z.object({
+    email: z.string().email('Email invalide')
+})
+
+export const load = (async (event) => {
+    const user = event.locals.user;
+    if (user) {
+        throw redirect(303, '/kodo');
+    }
+
+    const form = await superValidate(event, zod(newResetPasswordSchema));
+
+    return {
+        form
+    };
+}) satisfies PageServerLoad;
+
+export const actions: Actions = {
+    default: async (event) => {
+        const form = await superValidate(event, zod(newResetPasswordSchema));
+        if (!form.valid) {
+            return fail(400, {
+                form
+            });
+        }
+
+        const api = new AuthApi(event.fetch);
+        const res = await api.resetPasswordRequest(form.data.email);
+        if ("error" in res) {
+            return message(form, { error: res.error.message }, {
+                status: res.status
+            });
+        }
+
+        return message(form, { success: true });
+    }
+}

--- a/src/routes/(auth)/resetPassword/+page.svelte
+++ b/src/routes/(auth)/resetPassword/+page.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { superForm } from 'sveltekit-superforms/client';
+	import type { PageData } from './$types';
+	import Input from '$lib/Component/form/Input.svelte';
+	import Label from '$lib/Component/form/Label.svelte';
+	import SubmitButton from '$lib/Component/form/SubmitButton.svelte';
+	import toast from 'svelte-french-toast';
+	import ArrowLeftPicto from '$lib/Component/Picto/ArrowLeftPicto.svelte';
+	import { goBack } from '$lib/Utils/goBack';
+
+	export let data: PageData;
+
+	const { form, errors, enhance, message } = superForm(data.form, {
+		taintedMessage:
+			'Êtes vous sur de vouloir quitter cette page ? Les données ne seront pas sauvegardées'
+	});
+
+	$: if ($message?.success) {
+		$message.success = false;
+		toast.success('Un email vous a été envoyé');
+	}
+</script>
+
+<section class=" h-full mx-auto flex justify-center items-center w-full max-w-lg px-4">
+	<button on:click={goBack}>
+		<ArrowLeftPicto classCustom="w-6" />
+	</button>
+	<form method="post" use:enhance class="flex flex-col gap-8 w-full">
+		<div class="!max-w-36 mx-auto">
+			<img src="https://kodo.evift.fr/logo_base.png" alt="Logo Kodo" />
+		</div>
+		<div class="flex flex-col gap-8 w-full">
+			<div class="flex flex-col gap-8 w-full">
+				<Label label="Email"
+					><Input
+						placeholder="Email..."
+						error={$errors.email}
+						bind:value={$form.email}
+						name="email"
+						type="email"
+					/></Label
+				>
+			</div>
+			<SubmitButton>Envoyer</SubmitButton>
+		</div>
+	</form>
+</section>


### PR DESCRIPTION
Cette pull request introduit une fonctionnalité de réinitialisation de mot de passe et affine les flux d’authentification associés. Les changements clés incluent l’ajout de méthodes API pour la réinitialisation de mot de passe, une nouvelle logique côté serveur et client pour le traitement des demandes de réinitialisation, ainsi que des mises à jour de l’interface utilisateur pour une meilleure expérience.

### Fonctionnalité de réinitialisation de mot de passe

* **Améliorations de l’API** : Ajout de trois nouvelles méthodes à `AuthApi` dans `src/lib/Api/auth.server.ts` pour la gestion des demandes de réinitialisation de mot de passe (`resetPasswordRequest`, `chechResetRequest`, et `changePassword`). Ces méthodes interagissent avec le backend pour faciliter le workflow de réinitialisation.
* **Logique côté serveur** :
  - Création de `src/routes/(auth)/resetPassword/+page.server.ts` pour traiter les demandes de réinitialisation, incluant la validation du formulaire via `zod` et `sveltekit-superforms`.
  - Ajout de `src/routes/(auth)/changePassword/[userId]/[token]/+page.server.ts` pour valider les tokens de réinitialisation et gérer la soumission du nouveau mot de passe. ([src/routes/(auth)/changePassword/[userId]/[token]/+page.server.tsR1-R63](diffhunk://#diff-9833e21a6a15a8e88835d18c08a53cb30fc128470fdd79188b0a5954cc7e09c9R1-R63))
* **Interface utilisateur côté client** :
  - Implémentation de `src/routes/(auth)/resetPassword/+page.svelte` pour permettre aux utilisateurs de demander un email de réinitialisation.
  - Ajout de `src/routes/(auth)/changePassword/[userId]/[token]/+page.svelte` pour permettre la saisie d’un nouveau mot de passe après validation du token. ([src/routes/(auth)/changePassword/[userId]/[token]/+page.svelteR1-R56](diffhunk://#diff-26cdb390f4e9207fd8cab8c1399cbc5d76dbe3fa212644a37b6b79eec887e585R1-R56))

### Améliorations du flux d’authentification

* **Logique de redirection** : Ajout de redirections pour empêcher les utilisateurs déjà connectés d’accéder aux pages de réinitialisation ou de changement de mot de passe (`src/routes/(auth)/changePassword/+page.server.ts` et `src/routes/(auth)/changePassword/[userId]/+page.server.ts`). ([src/routes/(auth)/changePassword/+page.server.tsR1-R10](diffhunk://#diff-5f675acd769c758d2d0f45d21e3e243049c43e5c00688851e80afca3bf816907R1-R10), [src/routes/(auth)/changePassword/[userId]/+page.server.tsR1-R8](diffhunk://#diff-993c1bb5ef0274cb84b93e1c723406b978ee6309b0ed5fecebc09766c864f55dR1-R8))
* **Mise à jour de la page de connexion** : Le bouton « Mot de passe oublié » sur la page de connexion renvoie désormais vers la nouvelle page de demande de réinitialisation (`src/routes/(auth)/login/+page.svelte`).

### Divers

* **Gestion des erreurs** : Ajustement de la gestion des erreurs dans la logique de registre serveur pour passer directement les objets d’erreur au lieu des messages (`src/routes/(auth)/register/+page.server.ts`).
* **Débogage** : Ajout d’une instruction de log pour `$message` dans la page d’inscription (`src/routes/(auth)/register/+page.svelte`).